### PR TITLE
Remove starport, version wasmvm and update readme/examples

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,50 +16,36 @@ jobs:
             version: v0.12.1
             repository: https://github.com/ovrclk/akash.git
             namespace: AKASH
-            use_starport: 
-            starport_repo: https://github.com/tendermint/starport
           - project: sentinelhub
             project_bin: sentinelhub
             version: v0.6.2
             repository: https://github.com/sentinel-official/hub.git
             namespace: SENTINELHUB
-            use_starport: 
-            starport_repo: https://github.com/tendermint/starport
           - project: gaia
             project_bin: gaiad
             version: v4.2.1
             repository: https://github.com/cosmos/gaia
             namespace: GA
-            use_starport: 
-            starport_repo: https://github.com/tendermint/starport
           - project: kava
             project_bin: kvd
             version: v0.14.1
             repository: https://github.com/Kava-Labs/kava
             namespace: KA
-            use_starport: 
-            starport_repo: https://github.com/tendermint/starport
           - project: osmosis
             project_bin: osmosisd
             version: v1.0.1
             repository: https://github.com/osmosis-labs/osmosis
             namespace: OSMOSISD
-            use_starport: 
-            starport_repo: https://github.com/tendermint/starport
           - project: persistence
             project_bin: persistenceCore
             version: v0.1.3
             repository: https://github.com/persistenceOne/persistenceCore
             namespace: PERSISTENCECORE
-            use_starport: 
-            starport_repo: https://github.com/tendermint/starport
           - project: juno
             project_bin: junod
             version: lucina
             repository: https://github.com/CosmosContracts/Juno
             namespace: JUNOD
-            use_starport: "true"
-            starport_repo: https://github.com/tendermint/starport
     steps:
       - uses: actions/checkout@v2
       - name: build
@@ -70,7 +56,5 @@ jobs:
             --build-arg PROJECT_BIN=${{matrix.project_bin}} \
             --build-arg VERSION=${{matrix.version}} \
             --build-arg REPOSITORY=${{matrix.repository}} \
-            --build-arg NAMESPACE=${{matrix.namespace}} \
-            --build-arg USE_STARPORT=${{matrix.use_starport}} \
-            --build-arg STARPORT_REPO=${{matrix.starport_repo}}
+            --build-arg NAMESPACE=${{matrix.namespace}}
           docker push ghcr.io/${{ github.repository }}:${GITHUB_REF#refs/tags/}-${{matrix.project}}-${{matrix.version}}${{matrix.tag_suffix}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.16-buster AS build
 
 RUN apt-get update && \
-  apt-get install --no-install-recommends --assume-yes curl unzip  && \
+  apt-get install --no-install-recommends --assume-yes curl unzip && \
   apt-get clean
 
 FROM build AS aws
@@ -15,28 +15,12 @@ ARG PROJECT=akash
 ARG PROJECT_BIN=$PROJECT
 ARG VERSION=v0.12.1
 ARG REPOSITORY=https://github.com/ovrclk/akash.git
-ARG USE_STARPORT=$USE_STARPORT
-ARG STARPORT_REPO=$STARPORT_REPO
-ARG USE_WASM=$USE_WASM
-
-# Clone and build starport
-RUN if [ "$USE_STARPORT" = "true" ] \
-  ; then apt-get install -y git-lfs protobuf-compiler nodejs && \
-    git clone $STARPORT_REPO /starport \
-  ; fi
-WORKDIR /starport
-RUN if [ "$USE_STARPORT" = "true" ] \
-  ; then git checkout develop && make \
-  ; fi
 
 # Clone and build project
 RUN git clone $REPOSITORY /data
 WORKDIR /data
 RUN git checkout $VERSION
-RUN if ["$USE_STARPORT" = "true"] \
-  ; then starport chain build \
-  ; else make install \
-  ; fi
+RUN make install
 RUN mv $GOPATH/bin/$PROJECT_BIN /bin/$PROJECT_BIN
 
 FROM debian:buster
@@ -49,7 +33,8 @@ RUN apt-get update && \
 ARG PROJECT=akash
 ARG PROJECT_BIN=$PROJECT
 ARG PROJECT_DIR=.$PROJECT_BIN
-ARG VERSION=v0
+ARG VERSION=v0.12.1
+ARG WASMVM_VERSION=main
 ARG REPOSITORY=https://github.com/ovrclk/akash.git
 ARG NAMESPACE
 
@@ -70,8 +55,8 @@ EXPOSE 26656 \
 
 COPY --from=project /bin/$PROJECT_BIN /bin/$PROJECT_BIN
 COPY --from=aws /usr/src/aws /usr/src/aws
-ADD https://raw.githubusercontent.com/CosmWasm/wasmvm/main/api/libwasmvm.so /lib/libwasmvm.so
 RUN /usr/src/aws/install --bin-dir /usr/bin
+ADD https://raw.githubusercontent.com/CosmWasm/wasmvm/$WASMVM_VERSION/api/libwasmvm.so /lib/libwasmvm.so
 
 COPY run.sh /usr/bin/
 RUN chmod +x /usr/bin/run.sh

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[kava](https://github.com/Kava-Labs/kava)|`v0.14.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.3-kava-v0.14.1`|[Example](./kava)|
 |[osmosis](https://github.com/osmosis-labs/osmosis)|`v1.0.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.3-osmosis-v1.0.1`|[Example](./osmosis)|
 |[persistence](https://github.com/persistenceOne/persistenceCore)|`v0.1.3`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.3-persistence-v0.1.3`|[Example](./persistence)|
+|[juno](https://github.com/CosmosContracts/Juno)|`lucina`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.4-juno-lucina`|[Example](./juno)|
 
 ## Configuration
 

--- a/juno/deploy.yml
+++ b/juno/deploy.yml
@@ -3,10 +3,10 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.0.3-juno-latest
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.0.4-juno-lucina
     env:
       - MONIKER=node_1
-      - CHAIN_URL=https://raw.githubusercontent.com/sikkatech/tm-networks/master/cosmoshub-4/chain.json
+      - CHAIN_URL=https://raw.githubusercontent.com/nullMames/juno-on-akash/main/chain.json
       # - MINIMUM_GAS_PRICES=0.025ujuno
       #  - MINIMUM_GAS_PRICES=0.025ujuno no gas required
       #  - SNAPSHOT_BASE_URL=https://cosmos-nodes.s3.ap-southeast-2.amazonaws.com/juno/lucina/data/juno_lucina_20210721.tar

--- a/juno/docker-compose.yml
+++ b/juno/docker-compose.yml
@@ -11,8 +11,6 @@ services:
         VERSION: lucina
         REPOSITORY: https://github.com/CosmosContracts/Juno
         NAMESPACE: JUNOD
-        USE_STARPORT: "true"
-        STARPORT_REPO: https://github.com/tendermint/starport
     ports:
       - '26656:26656'
       - '26657:26657'
@@ -29,4 +27,3 @@ services:
       - ../.env
     volumes:
       - ./node-data:/root/.juno
-


### PR DESCRIPTION
After reading up on starport, I think this is only needed for setting up a chain, not actually running it. The project binary installed with `make install` doesn't require starport.

I've also versioned wasmvm in the Dockerfile (which is required by Juno), and updated the readme and examples etc. 

Let me know what you think - this all runs fine locally without starport etc. 